### PR TITLE
Fixed git-hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,9 @@ help:
 
 .PHONY: bootstrap
 bootstrap: ## Bootstrap local environment for first use
-	make git-hooks
+	@make git-hooks
 
 .PHONY: git-hooks
 git-hooks: ## Set up hooks in .githooks
-	@{ \
-		git submodule update --init .githooks \
-		git config core.hooksPath .githooks \
-	}
+	@git submodule update --init .githooks ; \
+	git config core.hooksPath .githooks \


### PR DESCRIPTION
This resolved the following error when running `make bootstrap`
```
▶ make bootstrap
make git-hooks
bash: -c: line 1: syntax error: unexpected end of file
make[1]: *** [git-hooks] Error 2
make: *** [bootstrap] Error 2
```