### PR TITLE
Matching the pattern of the template repos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  IMAGE_NAME: dwpdigital/example
+  IMAGE_NAME: dwpdigital/dataworks-repo-template-docker
 
 jobs:
   get-publish-version:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: High vulns Snyk PR scan
 on: pull_request
 
 env:
-  IMAGE_NAME: dwpdigital/example
+  IMAGE_NAME: dwpdigital/dataworks-repo-template-docker
 
 jobs:
   docker-build-and-scan:


### PR DESCRIPTION
The init script uses sed to replace the template name with the name of the new repo.  This change keeps this repo in line with that pattern.