### PR TITLE
adding TF and concourse pipelines for ecr mirroring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SHELL:=bash
 
+aws_profile=default
+aws_region=eu-west-2
+
 default: help
 
 .PHONY: help
@@ -9,9 +12,32 @@ help:
 .PHONY: bootstrap
 bootstrap: ## Bootstrap local environment for first use
 	@make git-hooks
+	pip3 install --user Jinja2 PyYAML boto3
+	@{ \
+		export AWS_PROFILE=$(aws_profile); \
+		export AWS_REGION=$(aws_region); \
+		python3 bootstrap_terraform.py; \
+	}
+	terraform fmt -recursive
 
 .PHONY: git-hooks
 git-hooks: ## Set up hooks in .githooks
-  @git submodule update --init .githooks ; \
-  git config core.hooksPath .githooks \
+	@git submodule update --init .githooks ; \
+	git config core.hooksPath .githooks \
 
+
+.PHONY: terraform-init
+terraform-init: ## Run `terraform init` from repo root
+	terraform init
+
+.PHONY: terraform-plan
+terraform-plan: ## Run `terraform plan` from repo root
+	terraform plan
+
+.PHONY: terraform-apply
+terraform-apply: ## Run `terraform apply` from repo root
+	terraform apply
+
+.PHONY: terraform-workspace-new
+terraform-workspace-new: ## Creates new Terraform workspace with Concourse remote execution. Run `terraform-workspace-new workspace=<workspace_name>`
+	fly -t aws-concourse execute --config create-workspace.yml --input repo=. -v workspace="$(workspace)"

--- a/aviator.yml
+++ b/aviator.yml
@@ -1,0 +1,16 @@
+spruce:
+  - base: ci/meta.yml
+    prune:
+      - meta
+    merge:
+      - with_in: ci/
+        regexp: ".*.yml"
+      - with_in: ci/jobs/
+        regexp: ".*.yml"
+    to: aviator_pipeline.yml
+fly:
+  name: repo-template-docker
+  target: aws-concourse
+  config: aviator_pipeline.yml
+  expose: true
+  check_creds: true

--- a/aviator.yml
+++ b/aviator.yml
@@ -9,7 +9,7 @@ spruce:
         regexp: ".*.yml"
     to: aviator_pipeline.yml
 fly:
-  name: repo-template-docker
+  name: example
   target: aws-concourse
   config: aviator_pipeline.yml
   expose: true

--- a/aviator.yml
+++ b/aviator.yml
@@ -9,7 +9,7 @@ spruce:
         regexp: ".*.yml"
     to: aviator_pipeline.yml
 fly:
-  name: example
+  name: dataworks-repo-template-docker
   target: aws-concourse
   config: aviator_pipeline.yml
   expose: true

--- a/bootstrap_terraform.py
+++ b/bootstrap_terraform.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import boto3
+import botocore
+import jinja2
+import os
+import sys
+import yaml
+import json
+
+
+def main():
+    if 'AWS_PROFILE' in os.environ:
+        boto3.setup_default_session(profile_name=os.environ['AWS_PROFILE'])
+    if 'AWS_REGION' in os.environ:
+        secrets_manager = boto3.client(
+            'secretsmanager', region_name=os.environ['AWS_REGION'])
+    else:
+        secrets_manager = boto3.client('secretsmanager')
+
+    try:
+        response = secrets_manager.get_secret_value(
+            SecretId="/concourse/dataworks/terraform")
+    except botocore.exceptions.ClientError as e:
+        error_message = e.response["Error"]["Message"]
+        if "The security token included in the request is invalid" in error_message:
+            print("ERROR: Invalid security token used when calling AWS Secrets Manager. Have you run `aws-sts` recently?")
+        else:
+            print("ERROR: Problem calling AWS Secrets Manager: {}".format(
+                error_message))
+        sys.exit(1)
+
+    config_data = yaml.load(
+        response['SecretBinary'], Loader=yaml.FullLoader)
+    config_data['terraform'] = json.loads(
+        response['SecretBinary'])["terraform"]
+
+    with open('terraform.tf.j2') as in_template:
+        template = jinja2.Template(in_template.read())
+    with open('terraform.tf', 'w+') as terraform_tf:
+        terraform_tf.write(template.render(config_data))
+    with open('terraform.tfvars.j2') as in_template:
+        template = jinja2.Template(in_template.read())
+    with open('terraform.tfvars', 'w+') as terraform_tfvars:
+        terraform_tfvars.write(template.render(config_data))
+    print("Terraform config successfully created")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/groups.yml
+++ b/ci/groups.yml
@@ -8,5 +8,5 @@ groups:
       - dataworks-repo-template-docker-pr
   - name: mirror
     jobs:
-      - mirror-dwpdigital-example-dev
-      - mirror-dwpdigital-example
+      - mirror-dwpdigital-dataworks-repo-template-docker-dev
+      - mirror-dwpdigital-dataworks-repo-template-docker

--- a/ci/groups.yml
+++ b/ci/groups.yml
@@ -1,0 +1,12 @@
+groups:
+  - name: master
+    jobs:
+      - management-dev
+      - management
+  - name: pull-request
+    jobs:
+      - dataworks-repo-template-docker-pr
+  - name: mirror
+    jobs:
+      - mirror-dwpdigital-example-dev
+      - mirror-dwpdigital-example

--- a/ci/jobs/management-dev.yml
+++ b/ci/jobs/management-dev.yml
@@ -1,0 +1,9 @@
+jobs:
+  - name: management-dev
+    max_in_flight: 1
+    plan:
+      - get: dataworks-repo-template-docker
+        trigger: true
+      - .: (( inject meta.plan.terraform-bootstrap ))
+      - .: (( inject meta.plan.terraform-apply ))
+      - .: (( inject meta.plan.terraform-plan ))

--- a/ci/jobs/management.yml
+++ b/ci/jobs/management.yml
@@ -5,7 +5,7 @@ jobs:
       - get: dataworks-repo-template-docker
         trigger: true
         passed:
-          - development
+          - management-dev
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-apply ))
         params:

--- a/ci/jobs/management.yml
+++ b/ci/jobs/management.yml
@@ -1,0 +1,15 @@
+jobs:
+  - name: management
+    max_in_flight: 1
+    plan:
+      - get: dataworks-repo-template-docker
+        trigger: true
+        passed:
+          - development
+      - .: (( inject meta.plan.terraform-bootstrap ))
+      - .: (( inject meta.plan.terraform-apply ))
+        params:
+          TF_WORKSPACE: "management"
+      - .: (( inject meta.plan.terraform-plan ))
+        params:
+          TF_WORKSPACE: "management"

--- a/ci/jobs/mirror.yml
+++ b/ci/jobs/mirror.yml
@@ -3,7 +3,7 @@ resources:
     type: registry-image-resource
     source:
       repository: dwpdigital/example
-    check_every: 1h
+    check_every: 5m
 
   - name: ecr-dwpdigital-example-dev
     .: (( inject meta.resources.ecr-resource ))

--- a/ci/jobs/mirror.yml
+++ b/ci/jobs/mirror.yml
@@ -1,0 +1,44 @@
+resources:
+  - name: dwpdigital-example
+    type: registry-image-resource
+    source:
+      repository: dwpdigital/example
+    check_every: 1h
+
+  - name: ecr-dwpdigital-example-dev
+    .: (( inject meta.resources.ecr-resource ))
+    source:
+      repository: "example"
+
+  - name: ecr-dwpdigital-example
+    .: (( inject meta.resources.ecr-resource ))
+    source:
+      repository: "example"
+      aws_role_arn: arn:aws:iam::((dataworks.aws_management_acc)):role/ci
+
+jobs:
+  - name: mirror-dwpdigital-example-dev
+    serial_groups: [example]
+    plan:
+      - get: dwpdigital-example
+        trigger: true
+        params:
+          format: oci
+        attempts: 3
+      - put: ecr-dwpdigital-example-dev
+        params:
+          image: "dwpdigital-example/image.tar"
+        attempts: 3
+
+  - name: mirror-dwpdigital-example
+    serial_groups: [example]
+    plan:
+      - get: dwpdigital-example
+        trigger: true
+        params:
+          format: oci
+        attempts: 3
+      - put: ecr-dwpdigital-example
+        params:
+          image: "dwpdigital-example/image.tar"
+        attempts: 3

--- a/ci/jobs/mirror.yml
+++ b/ci/jobs/mirror.yml
@@ -1,44 +1,44 @@
 resources:
-  - name: dwpdigital-example
+  - name: dwpdigital-dataworks-repo-template-docker
     type: registry-image-resource
     source:
-      repository: dwpdigital/example
+      repository: dwpdigital/dataworks-repo-template-docker
     check_every: 5m
 
-  - name: ecr-dwpdigital-example-dev
+  - name: ecr-dwpdigital-dataworks-repo-template-docker-dev
     .: (( inject meta.resources.ecr-resource ))
     source:
-      repository: "example"
+      repository: "dataworks-repo-template-docker"
 
-  - name: ecr-dwpdigital-example
+  - name: ecr-dwpdigital-dataworks-repo-template-docker
     .: (( inject meta.resources.ecr-resource ))
     source:
-      repository: "example"
+      repository: "dataworks-repo-template-docker"
       aws_role_arn: arn:aws:iam::((dataworks.aws_management_acc)):role/ci
 
 jobs:
-  - name: mirror-dwpdigital-example-dev
-    serial_groups: [example]
+  - name: mirror-dwpdigital-dataworks-repo-template-docker-dev
+    serial_groups: [dataworks-repo-template-docker]
     plan:
-      - get: dwpdigital-example
+      - get: dwpdigital-dataworks-repo-template-docker
         trigger: true
         params:
           format: oci
         attempts: 3
-      - put: ecr-dwpdigital-example-dev
+      - put: ecr-dwpdigital-dataworks-repo-template-docker-dev
         params:
-          image: "dwpdigital-example/image.tar"
+          image: "dwpdigital-dataworks-repo-template-docker/image.tar"
         attempts: 3
 
-  - name: mirror-dwpdigital-example
-    serial_groups: [example]
+  - name: mirror-dwpdigital-dataworks-repo-template-docker
+    serial_groups: [dataworks-repo-template-docker]
     plan:
-      - get: dwpdigital-example
+      - get: dwpdigital-dataworks-repo-template-docker
         trigger: true
         params:
           format: oci
         attempts: 3
-      - put: ecr-dwpdigital-example
+      - put: ecr-dwpdigital-dataworks-repo-template-docker
         params:
-          image: "dwpdigital-example/image.tar"
+          image: "dwpdigital-dataworks-repo-template-docker/image.tar"
         attempts: 3

--- a/ci/jobs/pr.yml
+++ b/ci/jobs/pr.yml
@@ -1,0 +1,31 @@
+jobs:
+  - name: dataworks-repo-template-docker-pr
+    plan:
+      - get: dataworks-repo-template-docker-pr
+        trigger: true
+        version: every
+      - put: dataworks-repo-template-docker-pr
+        params:
+          path: dataworks-repo-template-docker-pr
+          status: pending
+        input_mapping:
+          dataworks-repo-template-docker: dataworks-repo-template-docker-pr
+      - .: (( inject meta.plan.terraform-bootstrap ))
+        input_mapping:
+          dataworks-repo-template-docker: dataworks-repo-template-docker-pr
+      - .: (( inject meta.plan.terraform-plan ))
+        input_mapping:
+          dataworks-repo-template-docker: dataworks-repo-template-docker-pr
+        params:
+          TF_WORKSPACE: "management-dev"
+          DETAILED_EXITCODE: ""
+        on_failure:
+          put: dataworks-repo-template-docker-pr
+          params:
+            path: dataworks-repo-template-docker-pr
+            status: failure
+        on_success:
+          put: dataworks-repo-template-docker-pr
+          params:
+            path: dataworks-repo-template-docker-pr
+            status: success

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -1,0 +1,86 @@
+meta:
+  resources:
+    - name: ecr-resource
+      type: registry-image-resource
+      source:
+        repository: unset
+        aws_region: ((dataworks.aws_region))
+        aws_role_arn: arn:aws:iam::((dataworks.aws_management_dev_acc)):role/ci
+        aws_access_key_id: ((dataworks-secrets.ci_aws_access_key_id))
+        aws_secret_access_key: ((dataworks-secrets.ci_aws_secret_access_key))
+  plan:
+    terraform-common-config:
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((dataworks.terraform_repository))
+            tag: ((dataworks.terraform_version))
+        params:
+          TF_INPUT: false
+          TF_CLI_ARGS_apply: -lock-timeout=300s
+          TF_CLI_ARGS_plan: -lock-timeout=300s
+          TF_VAR_costcode: ((dataworks.costcode))
+    terraform-bootstrap:
+      task: terraform-bootstrap
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: dwpdigital/jinja-yaml-aws
+            version: 0.0.19
+            tag: 0.0.19
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              python bootstrap_terraform.py
+              cp terraform.tf ../terraform-bootstrap
+          dir: dataworks-repo-template-docker
+        inputs:
+          - name: dataworks-repo-template-docker
+        outputs:
+          - name: terraform-bootstrap
+      params:
+        AWS_REGION: eu-west-2
+    terraform-apply:
+      task: terraform-apply
+      .: (( inject meta.plan.terraform-common-config ))
+      config:
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cp ../terraform-bootstrap/terraform.tf .
+              terraform workspace show
+              #ENABLE_BY_INITIAL_COMMIT terraform init
+              #ENABLE_BY_INITIAL_COMMIT terraform plan -out terraform.plan
+              #ENABLE_BY_INITIAL_COMMIT terraform apply -auto-approve terraform.plan
+          dir: dataworks-repo-template-docker
+        inputs:
+          - name: dataworks-repo-template-docker
+          - name: terraform-bootstrap
+    terraform-plan:
+      task: terraform-plan
+      .: (( inject meta.plan.terraform-common-config ))
+      config:
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cp ../terraform-bootstrap/terraform.tf .
+              terraform workspace show
+              terraform init -backend=false; terraform validate #REMOVE_BY_INITIAL_COMMIT
+              #ENABLE_BY_INITIAL_COMMIT terraform init
+              #ENABLE_BY_INITIAL_COMMIT terraform plan $DETAILED_EXITCODE
+          dir: dataworks-repo-template-docker
+        inputs:
+          - name: dataworks-repo-template-docker
+          - name: terraform-bootstrap
+      params:
+        DETAILED_EXITCODE: -detailed-exitcode

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -44,8 +44,6 @@ meta:
           - name: dataworks-repo-template-docker
         outputs:
           - name: terraform-bootstrap
-      params:
-        AWS_REGION: eu-west-2
     terraform-apply:
       task: terraform-apply
       .: (( inject meta.plan.terraform-common-config ))

--- a/ci/resource_types.yml
+++ b/ci/resource_types.yml
@@ -1,0 +1,12 @@
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: teliaoss/github-pr-resource
+      tag: latest
+
+  - name: registry-image-resource
+    type: docker-image
+    source:
+      repository: chrisscottthomas/registry-image-resource
+      tag: latest

--- a/ci/resource_types.yml
+++ b/ci/resource_types.yml
@@ -8,5 +8,5 @@ resource_types:
   - name: registry-image-resource
     type: docker-image
     source:
-      repository: chrisscottthomas/registry-image-resource
+      repository: dwpdigital/registry-image-resource
       tag: latest

--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -1,0 +1,17 @@
+resources:
+  - name: dataworks-repo-template-docker-pr
+    type: pull-request
+    source:
+      repository: dwp/dataworks-repo-template-docker
+      access_token: ((dataworks-secrets.concourse_github_pat))
+    webhook_token: ((dataworks.concourse_github_webhook_token))
+    check_every: 720h
+
+  - name: dataworks-repo-template-docker
+    type: git
+    source:
+      branch: master
+      uri: https://github.com/dwp/dataworks-repo-template-docker.git
+      access_token: ((dataworks-secrets.concourse_github_pat))
+    webhook_token: ((dataworks.concourse_github_webhook_token))
+    check_every: 720h

--- a/ecr.tf
+++ b/ecr.tf
@@ -1,0 +1,16 @@
+resource "aws_ecr_repository" "example" {
+  name = "hive-exporter"
+  tags = merge(
+    local.common_tags,
+    { DockerHub : "dwpdigital/hive-exporter" }
+  )
+}
+
+resource "aws_ecr_repository_policy" "example" {
+  repository = aws_ecr_repository.example.name
+  policy     = data.terraform_remote_state.management.outputs.ecr_iam_policy_document
+}
+
+output "ecr_example_url" {
+  value = aws_ecr_repository.example.repository_url
+}

--- a/ecr.tf
+++ b/ecr.tf
@@ -1,8 +1,8 @@
 resource "aws_ecr_repository" "example" {
-  name = "hive-exporter"
+  name = "example"
   tags = merge(
     local.common_tags,
-    { DockerHub : "dwpdigital/hive-exporter" }
+    { DockerHub : "dwpdigital/example" }
   )
 }
 

--- a/ecr.tf
+++ b/ecr.tf
@@ -1,16 +1,16 @@
-resource "aws_ecr_repository" "example" {
-  name = "example"
+resource "aws_ecr_repository" "dataworks-repo-template-docker" {
+  name = "dataworks-repo-template-docker"
   tags = merge(
     local.common_tags,
-    { DockerHub : "dwpdigital/example" }
+    { DockerHub : "dwpdigital/dataworks-repo-template-docker" }
   )
 }
 
-resource "aws_ecr_repository_policy" "example" {
-  repository = aws_ecr_repository.example.name
+resource "aws_ecr_repository_policy" "dataworks-repo-template-docker" {
+  repository = aws_ecr_repository.dataworks-repo-template-docker.name
   policy     = data.terraform_remote_state.management.outputs.ecr_iam_policy_document
 }
 
 output "ecr_example_url" {
-  value = aws_ecr_repository.example.repository_url
+  value = aws_ecr_repository.dataworks-repo-template-docker.repository_url
 }

--- a/terraform.tf.j2
+++ b/terraform.tf.j2
@@ -1,0 +1,67 @@
+terraform {
+  required_version = "{{terraform.terraform_12_version}}"
+
+  backend "s3" {
+    bucket         = "{{terraform.state_file_bucket}}"
+    key            = "terraform/dataworks/dataworks-repo-template-docker.tfstate"
+    region         = "{{terraform.state_file_region}}"
+    encrypt        = true
+    kms_key_id     = "arn:aws:kms:{{terraform.state_file_region}}:{{terraform.state_file_account}}:key/{{terraform.state_file_kms_key}}"
+    dynamodb_table = "remote_state_locks"
+  }
+}
+
+data "terraform_remote_state" "management" {
+  backend = "s3"
+  workspace = "management"
+
+  config = {
+    bucket         = "{{state_file_bucket}}"
+    key            = "terraform/dataworks/management.tfstate"
+    region         = "{{state_file_region}}"
+    encrypt        = true
+    kms_key_id     = "arn:aws:kms:{{state_file_region}}:{{state_file_account}}:key/{{state_file_kms_key}}"
+    dynamodb_table = "remote_state_locks"
+  }
+}
+
+provider "aws" {
+  version = "~> 2.66.0"
+  region  = "{{terraform.provider_region}}"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${lookup(local.account, local.environment)}:role/${var.assume_role}"
+  }
+}
+
+locals {
+  name        = "dataworks-repo-template-docker"
+  environment = terraform.workspace == "default" ? "development" : terraform.workspace
+
+  account = {
+    {%- for key, value in accounts.items() %}
+      {{key}} = "{{value}}"
+    {%- endfor %}
+  }
+
+  common_tags = {
+    {%- for key, value in common_tags.items() %}
+      {{key}} = "{{value}}"
+    {%- endfor %}
+    Name         = local.name
+    Environment  = local.environment
+    Application  = local.name
+    Persistence  = "True"
+    AutoShutdown = "False"
+    Costcode     = var.costcode
+    Team         = "DataWorks"
+  }
+
+  cidr_block = {
+  {%- for environment, ranges in cidr_block.items() %}
+      {{ environment }} = {
+        {%- for key, value in ranges.items() %}
+          {{ key }} = "{{ value }}"{% endfor %}
+      } {%- endfor %}
+  }
+}

--- a/terraform.tfvars.j2
+++ b/terraform.tfvars.j2
@@ -1,0 +1,1 @@
+assume_role = "administrator"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,15 @@
+variable "costcode" {
+  type    = string
+  default = ""
+}
+
+variable "assume_role" {
+  type        = string
+  default     = "ci"
+  description = "IAM role assumed by Concourse when running Terraform"
+}
+
+variable "region" {
+  type    = string
+  default = "eu-west-2"
+}


### PR DESCRIPTION
In order for each container image repo to mange its own mirroring to ECR, we've had to extend the scope of this template repo to include Terraform and Concourse pipelines.
This includes creating entries in ECR, and the mirroring tasks in Concourse.